### PR TITLE
update componentWillReceiveProps to componentDidUpdate

### DIFF
--- a/src/components/indicator/index.js
+++ b/src/components/indicator/index.js
@@ -101,7 +101,7 @@ export default class Indicator extends PureComponent {
     this.mounted = false;
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     let { animating } = this.props;
 
     if (animating ^ props.animating) {


### PR DESCRIPTION
Fix for issue #26
componentWillReceiveProps is an sync function which is being deprecated in favor of  using componentDidUpdate which is async. Also fixes a rendering issue I found on Android.