### PR TITLE
Make loops work on web

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,17 +2,17 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
-        compileSdkVersion = 28
-        targetSdkVersion = 28
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+        classpath("com.android.tools.build:gradle:4.2.2")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -32,7 +32,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/src/components/indicator/index.js
+++ b/src/components/indicator/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Easing } from 'react-native';
+import { Animated, Easing, Platform } from 'react-native';
 
 export default class Indicator extends PureComponent {
   static defaultProps = {
@@ -94,7 +94,7 @@ export default class Indicator extends PureComponent {
       .timing(progress, {
         duration: animationDuration,
         easing: animationEasing,
-        useNativeDriver: true,
+        useNativeDriver: Platform.OS !== 'web', // Web doesn't support loops if using Native Driver
         isInteraction: interaction,
         toValue: 1,
       });


### PR DESCRIPTION
Currently `react-native-indicator` doesn't work with `react-native-web` due to the fact that `_startNativeLoop` implementation on web is not working due to the missing `NativeAnimatedModule` for web:
https://github.com/necolas/react-native-web/blob/a877a02beb6a2032430f83b062e173d68c40c65d/packages/react-native-web/src/vendor/react-native/Animated/NativeAnimatedHelper.js#L266

That's why the only way to make it work on web is to turn off the native driver and switch to recursive calls on JS thread:
https://github.com/necolas/react-native-web/blob/a877a02beb6a2032430f83b062e173d68c40c65d/packages/react-native-web/src/vendor/react-native/Animated/AnimatedImplementation.js#L452