### PR TITLE
useNativeDriver in Animation restart on update

### DIFF
--- a/src/components/indicator/index.js
+++ b/src/components/indicator/index.js
@@ -77,7 +77,7 @@ export default class Indicator extends PureComponent {
       let { hideAnimationDuration: duration } = this.props;
 
       Animated
-        .timing(hideAnimation, { toValue: animating? 1 : 0, duration })
+        .timing(hideAnimation, { toValue: animating? 1 : 0, duration, useNativeDriver: true })
         .start();
     }
   }


### PR DESCRIPTION
This library causes a lot of warnings, since `useNativeDriver` is a required property in Animated.timing. So i added `useNativeDriver` in the Animation in  `componentDidUpdate` according to the other uses.