### PR TITLE
Get rid of spread operator for prop key

### DIFF
--- a/src/components/ball-indicator/index.js
+++ b/src/components/ball-indicator/index.js
@@ -64,7 +64,7 @@ export default class BallIndicator extends PureComponent {
     };
 
     return (
-      <Animated.View style={[styles.layer, layerStyle]} {...{ key: index }}>
+      <Animated.View key={index} style={[styles.layer, layerStyle]}>
         <Animated.View style={ballStyle} />
       </Animated.View>
     );


### PR DESCRIPTION
key is a special prop in React that's used for reconciliation. React recommends handling it separately from other props.
Generates errors in react-native v75.3 if not handled properly.